### PR TITLE
Fix error handling

### DIFF
--- a/py_tegra_swizzle/__init__.py
+++ b/py_tegra_swizzle/__init__.py
@@ -47,13 +47,28 @@ def deswizzle_block_linear(width: int, height: int, depth: int, source: bytes, b
     :param width: The width of the surface in blocks
     :param height: The height of the surface in blocks
     :param depth: The depth of the surface in blocks
+    :param source: The swizzled data for the surface
+    :param block_height: The block height (1,2,4,8,16,32)
+    :param bytes_per_pixel: Number of bytes per pixel
+
+    :returns: The raw surface as bytes
+    """
+    return rust.deswizzle_block_linear(width, height, depth, source, block_height, bytes_per_pixel)
+
+def swizzle_block_linear(width: int, height: int, depth: int, source: bytes, block_height: int, bytes_per_pixel: int) -> bytes:
+    """
+    Tiles the blocks from source using block linear format.
+    
+    :param width: The width of the surface in blocks
+    :param height: The height of the surface in blocks
+    :param depth: The depth of the surface in blocks
     :param source: The raw data for the surface
     :param block_height: The block height (1,2,4,8,16,32)
     :param bytes_per_pixel: Number of bytes per pixel
 
-    :returns: The deswizzled surface as bytes
+    :returns: The swizzled surface as bytes
     """
-    return rust.deswizzle_block_linear(width, height, depth, source, block_height, bytes_per_pixel)
+    return rust.swizzle_block_linear(width, height, depth, source, block_height, bytes_per_pixel)
 
 __version__ = version.version
 VERSION = version.version

--- a/py_tegra_swizzle/rust.pyi
+++ b/py_tegra_swizzle/rust.pyi
@@ -60,9 +60,23 @@ def deswizzle_block_linear(width: int, height: int, depth: int, source: bytes, b
     :param width: The width of the surface in blocks
     :param height: The height of the surface in blocks
     :param depth: The depth of the surface in blocks
-    :param source: The raw data for the surface
+    :param source: The swizzled data for the surface
     :param block_height: The block height (1,2,4,8,16,32)
     :param bytes_per_pixel: Number of bytes per pixel
 
     :returns: The deswizzled surface as bytes
+    """
+
+def swizzle_block_linear(width: int, height: int, depth: int, source: bytes, block_height: int, bytes_per_pixel: int) -> bytes:
+    """
+    Tiles the blocks from source using block linear format.
+    
+    :param width: The width of the surface in blocks
+    :param height: The height of the surface in blocks
+    :param depth: The depth of the surface in blocks
+    :param source: The raw data for the surface
+    :param block_height: The block height (1,2,4,8,16,32)
+    :param bytes_per_pixel: Number of bytes per pixel
+
+    :returns: The swizzled surface as bytes
     """


### PR DESCRIPTION
throws an actual ValueError instead of a rust panic

![image](https://github.com/user-attachments/assets/659dafe4-3562-4d8b-8832-e3a4efc84cb2)
